### PR TITLE
fix tests

### DIFF
--- a/airbyte_dbt_airflow_teradata/dbt_project/models/ecommerce/staging/schema.yml
+++ b/airbyte_dbt_airflow_teradata/dbt_project/models/ecommerce/staging/schema.yml
@@ -12,7 +12,7 @@ models:
           - name: academic_degree
             tests:
                 - not_null
-          - name: title
+          - name: _title
             tests:
                 - not_null
           - name: nationality
@@ -66,7 +66,7 @@ models:
           - name: id
             tests:
                 - unique
-          - name: year
+          - name: _year
             tests:
                 - not_null
           - name: price

--- a/airbyte_dbt_airflow_teradata/dbt_project/models/ecommerce/staging/stg_products.sql
+++ b/airbyte_dbt_airflow_teradata/dbt_project/models/ecommerce/staging/stg_products.sql
@@ -1,6 +1,6 @@
 select
     CAST (_airbyte_data.JSONExtractValue('$.id')  AS int)  as id,
-    CAST (_airbyte_data.JSONExtractValue('$.year')   AS int) as myear,
+    CAST (_airbyte_data.JSONExtractValue('$.year')   AS int) as _year,
      CAST (_airbyte_data.JSONExtractValue('$.price')    AS int)  as price,
      CAST (_airbyte_data.JSONExtractValue('$.model')  AS VARCHAR(200)) as model,
 	 CAST (_airbyte_data.JSONExtractValue('$.make')  AS VARCHAR(200)) as make,

--- a/airbyte_dbt_airflow_teradata/dbt_project/models/ecommerce/staging/stg_users.sql
+++ b/airbyte_dbt_airflow_teradata/dbt_project/models/ecommerce/staging/stg_users.sql
@@ -2,7 +2,7 @@ select
     CAST (_airbyte_data.JSONExtractValue('$.id')  AS int)  as id,
     CAST (_airbyte_data.JSONExtractValue('$.gender')   AS VARCHAR(50)) as gender,
      CAST (_airbyte_data.JSONExtractValue('$.academic_degree')    AS VARCHAR(50))  as academic_degree,
-     CAST (_airbyte_data.JSONExtractValue('$.title')  AS VARCHAR(200)) as mtitle,
+     CAST (_airbyte_data.JSONExtractValue('$.title')  AS VARCHAR(200)) as _title,
 	 CAST (_airbyte_data.JSONExtractValue('$.nationality')  AS VARCHAR(50)) as nationality,	 
 	 CAST (_airbyte_data.JSONExtractValue('$.age')  AS int) as age,
 	 CAST (_airbyte_data.JSONExtractValue('$.name')  AS VARCHAR(200)) as name,


### PR DESCRIPTION
The column names in the json shredding views were changed to avoid clashes with teradata unique keywords, but the tests in were not adjusted to the new names. This PR aligns tests with view column names.